### PR TITLE
Add Encoding to DbfFile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ homepage = "https://github.com/rory/rust-dbf"
 
 [dependencies]
 nom = "^2.0"
+thiserror = "1.0"


### PR DESCRIPTION
This merge request introduces the ability to specify the encoding when decoding bytes. 

This is achieved by adding a new field `_from_v8` to the `Dbffile` struct. 
This allows users to provide a function that uses their desired encoding method for the conversion.
